### PR TITLE
Add class to decks

### DIFF
--- a/db/migrations/20180526133313_initial.js
+++ b/db/migrations/20180526133313_initial.js
@@ -1,5 +1,5 @@
 
-exports.up = function(knex, Promise) {
+exports.up = function (knex, Promise) {
 
   return Promise.all([
     knex.schema.createTable('cards', (table) => {
@@ -16,10 +16,11 @@ exports.up = function(knex, Promise) {
     }),
 
     knex.schema.createTable('decks', (table) => {
-      table.increments('id').primary()
+      table.increments('id').primary();
       table.string('name');
+      table.string('class')
 
-      table.timestamps(true, true,);
+      table.timestamps(true, true);
     }),
 
     knex.schema.createTable('joins', (table) => {
@@ -33,7 +34,7 @@ exports.up = function(knex, Promise) {
     })
 
   ])
-  
+
 };
 
 exports.down = function (knex, Promise) {

--- a/db/seeds/dev/cards.js
+++ b/db/seeds/dev/cards.js
@@ -29,8 +29,8 @@ exports.seed = (knex, Promise) => database.migrate.rollback()
   // add two records to decks table
   .then(() => {
     return Promise.all([
-      knex('decks').insert({ id: 1, name: 'Brute Deck' }),
-      knex('decks').insert({ id: 2, name: 'Cragheart Deck' }),
+      knex('decks').insert({ id: 1, name: 'Brute Deck', class: 'Brute' }),
+      knex('decks').insert({ id: 2, name: 'Cragheart Deck', class: 'Cragheart' })
     ]);
   })
 

--- a/db/seeds/test/cards.js
+++ b/db/seeds/test/cards.js
@@ -29,9 +29,9 @@ exports.seed = (knex, Promise) => database.migrate.rollback()
   // add two records to decks table
   .then(() => {
     return Promise.all([
-      knex('decks').insert({ name: 'Brute Deck' }),
-      knex('decks').insert({ name: 'Cragheart Deck' }),
-      knex('decks').insert({ name: 'Mindthief Deck' }),
+      knex('decks').insert({ name: 'Brute Deck', class: 'Brute' }),
+      knex('decks').insert({ name: 'Cragheart Deck', class: 'Cragheart' }),
+      knex('decks').insert({ name: 'Mindthief Deck', class: 'Mindthief' }),
     ]);
   })
 

--- a/db/seeds/test/cards.js
+++ b/db/seeds/test/cards.js
@@ -31,7 +31,7 @@ exports.seed = (knex, Promise) => database.migrate.rollback()
     return Promise.all([
       knex('decks').insert({ name: 'Brute Deck', class: 'Brute' }),
       knex('decks').insert({ name: 'Cragheart Deck', class: 'Cragheart' }),
-      knex('decks').insert({ name: 'Mindthief Deck', class: 'Mindthief' }),
+      knex('decks').insert({ name: 'Mindthief Deck', class: 'Mindthief' })
     ]);
   })
 

--- a/server.js
+++ b/server.js
@@ -70,7 +70,7 @@ app.post('/api/v1/decks', (request, response) => {
   const deckName = request.body.name;
   const cardArray = request.body.cards;
 
-  for (let requiredParameter of ['name', 'cards']) {
+  for (let requiredParameter of ['name', 'cards', 'class']) {
     if (!deck[requiredParameter]) {
       return response.status(422)
         .json(`You are missing a ${requiredParameter} parameter.`);

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -115,6 +115,7 @@ describe('API Routes', () => {
         .post('/api/v1/decks')
         .send({
           name: 'Ultra Mega Awesome Tinkerer',
+          class: 'Tinkerer',
           cards: [144, 145, 146, 147, 148, 149, 150]
         })
         .end((err, response) => {
@@ -129,6 +130,7 @@ describe('API Routes', () => {
       chai.request(app)
         .post('/api/v1/decks')
         .send({
+          class: 'Tinkerer',
           cards: [144, 145, 146, 147, 148, 149, 150]
         })
         .end((err, response) => {
@@ -144,6 +146,7 @@ describe('API Routes', () => {
         .post('/api/v1/decks')
         .send({
           name: 'Ultra Mega Awesome Tinkerer',
+          class: 'Tinkerer',
           cards: []
         })
         .end((err, response) => {


### PR DESCRIPTION
In order to use class routes in React, class field was added to the decks table.  Migration and seeds were updated.  May require deleting existing tables from databases before rollback, latest, seed in both environments.  Updated server.js to include class as required parameter.  Updated tests to include class parameter.