### PR TITLE
Deckbuilder components

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,11 @@ app.locals.title = 'Gloomhaven Deck-Builder';
 
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(function (request, response, next) {
+  response.header("Access-Control-Allow-Origin", "*");
+  response.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
 
 app.listen(app.get('port'), () => {
   console.log(`${app.locals.title} is running on port ${app.get('port')}`); //eslint-disable-line

--- a/server.js
+++ b/server.js
@@ -56,6 +56,7 @@ app.get('/api/v1/decks/:id', (request, response) => {
               });
               return response.status(200).json({
                 name: deck[0].name,
+                class: deck[0].class,
                 cards: cardsArray
               });
             } else {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,3 +8,43 @@ export const addCards = (cards) => ({
   cards
 });
 
+export const removeCards = (cards) => ({
+  type: 'REMOVE_CARDS',
+  cards
+});
+
+export const addSelectedCard = (selectedCard) => ({
+  type: 'ADD_SELECTED_CARD',
+  selectedCard
+});
+
+export const addSelectedCards = (selectedCards) => ({
+  type: 'ADD_SELECTED_CARDS',
+  selectedCards
+});
+
+export const removeSelectedCard = (selectedCard) => ({
+  type: 'REMOVE_SELECTED_CARD',
+  selectedCard
+});
+
+export const removeSelectedCards = (selectedCards) => ({
+  type: 'REMOVE_SELECTED_CARDS',
+  selectedCards
+});
+
+export const addAvailableCard = (availableCard) => ({
+  type: 'ADD_AVAILABLE_CARD',
+  availableCard
+});
+
+export const addAvailableCards = (availableCards) => ({
+  type: 'ADD_AVAILABLE_CARDS',
+  availableCards
+});
+
+export const removeAvailableCard = (availableCard) => ({
+  type: 'REMOVE_AVAILABLE_CARD',
+  availableCard
+});
+

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -48,3 +48,8 @@ export const removeAvailableCard = (availableCard) => ({
   availableCard
 });
 
+export const addSelectedClass = (selectedClass) => ({
+  type: 'ADD_SELECTED_CLASS',
+  selectedClass
+});
+

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,1 +1,10 @@
-// PLACE HOLDER
+export const addCard = (card) => ({
+  type: 'ADD_CARD',
+  card
+});
+
+export const addCards = (cards) => ({
+  type: 'ADD_CARDS',
+  cards
+});
+

--- a/src/api/fetchCards.js
+++ b/src/api/fetchCards.js
@@ -1,0 +1,11 @@
+export const fetchCards = async (selectedClass) => {
+  const url = `http://localhost:8080/api/v1/cards/${selectedClass}`;
+
+  try {
+    const response = await fetch(url);
+    const cards = await response.json();
+    return cards
+  } catch (error) {
+    throw error("Error getting cards")
+  }
+}

--- a/src/api/fetchSelected.js
+++ b/src/api/fetchSelected.js
@@ -1,0 +1,11 @@
+export const fetchSelected = async (deckId) => {
+  const url = `http://localhost:8080/api/v1/decks/${deckId}`;
+
+  try {
+    const response = await fetch(url);
+    const deck = await response.json();
+    return deck.cards;
+  } catch (error) {
+    throw error("Error getting deck")
+  }
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,2 @@
+export { fetchCards } from './fetchCards';
+export { fetchSelected } from './fetchSelected'

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -1,1 +1,11 @@
-/* PLACEHOLDER */
+header {
+  position: absolute;
+  top: 0;
+  height: 100px
+}
+
+footer {
+  position: absolute;
+  bottom: 0;
+  height: 100px
+}

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -1,11 +1,19 @@
+body {
+  background-color: black;
+}
+
 header {
   position: absolute;
   top: 0;
-  height: 100px
+  height: 50px
 }
 
 footer {
   position: absolute;
   bottom: 0;
-  height: 100px
+  height: 50px
+}
+
+h1 {
+  margin: 5px;
 }

--- a/src/components/AvailableCards/AvailableCards.css
+++ b/src/components/AvailableCards/AvailableCards.css
@@ -1,1 +1,16 @@
-/* PLACEHOLDER */
+.cards-component {
+  width: 42%;
+  margin-bottom: 85px;
+}
+
+#available-component {
+}
+
+.cards-container {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  padding-top: 5px;
+  height: 100%;
+  overflow: scroll;
+}

--- a/src/components/AvailableCards/AvailableCards.css
+++ b/src/components/AvailableCards/AvailableCards.css
@@ -1,6 +1,11 @@
 .cards-component {
   width: 42%;
-  margin-bottom: 85px;
+  margin-bottom: 60px;
+}
+
+.cards-component h2 {
+  color: white;
+  margin: 10px;
 }
 
 #available-component {
@@ -9,8 +14,8 @@
 .cards-container {
   display: flex;
   flex-wrap: wrap;
-  align-content: center;
-  padding-top: 5px;
+  justify-content: space-between;
   height: 100%;
   overflow: scroll;
 }
+

--- a/src/components/AvailableCards/AvailableCards.js
+++ b/src/components/AvailableCards/AvailableCards.js
@@ -1,10 +1,35 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import './AvailableCards.css';
+import { Card } from '../Card/Card'
 
-export const AvailableCards = () => {
+export const AvailableCards = ({cards}) => {
+  let displayCards
+
+  console.log(cards)
+
+  if (cards) {
+    displayCards = cards.map(card => {
+      console.log(card)
+    return <Card
+      key={card.id}
+      image={card.image_url}
+      name={card.name} />;
+    });
+  }
+
   return (
-    <div>
-      <h1>AvailableCards</h1>
+    <div class="cards-component" id="available-component">
+      <h1>Available Cards</h1>
+      <div class="cards-container">
+        {displayCards}
+      </div>
     </div>
   );
-};
+}
+
+export const mapStateToProps = state => ({
+  cards: state.cards
+});
+
+export default connect(mapStateToProps)(AvailableCards);

--- a/src/components/AvailableCards/AvailableCards.js
+++ b/src/components/AvailableCards/AvailableCards.js
@@ -3,14 +3,11 @@ import { connect } from 'react-redux';
 import './AvailableCards.css';
 import { Card } from '../Card/Card'
 
-export const AvailableCards = ({cards}) => {
+export const AvailableCards = ({ cards }) => {
   let displayCards
-
-  console.log(cards)
 
   if (cards) {
     displayCards = cards.map(card => {
-      console.log(card)
     return <Card
       key={card.id}
       image={card.image_url}
@@ -19,9 +16,9 @@ export const AvailableCards = ({cards}) => {
   }
 
   return (
-    <div class="cards-component" id="available-component">
+    <div className="cards-component" id="available-component">
       <h1>Available Cards</h1>
-      <div class="cards-container">
+      <div className="cards-container">
         {displayCards}
       </div>
     </div>
@@ -29,7 +26,9 @@ export const AvailableCards = ({cards}) => {
 }
 
 export const mapStateToProps = state => ({
-  cards: state.cards
+  cards: state.cards,
+  selectedCards: state.selectedCards,
+  availableCards: state.availableCards
 });
 
 export default connect(mapStateToProps)(AvailableCards);

--- a/src/components/AvailableCards/AvailableCards.js
+++ b/src/components/AvailableCards/AvailableCards.js
@@ -17,7 +17,7 @@ export const AvailableCards = ({ cards }) => {
 
   return (
     <div className="cards-component" id="available-component">
-      <h1>Available Cards</h1>
+      <h2>Available Cards</h2>
       <div className="cards-container">
         {displayCards}
       </div>

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -1,8 +1,8 @@
 .card {
-  width: 150px;
+  width: 120px;
   margin: 5px;
 }
 
 .card img {
-  height: 200px;
+  width: 100%;
 }

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -1,0 +1,8 @@
+.card {
+  width: 150px;
+  margin: 5px;
+}
+
+.card img {
+  height: 200px;
+}

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,0 +1,14 @@
+import './Card.css';
+import React from 'react';
+
+export const Card = (card) => {
+
+  console.log(this.props)
+  
+  return (
+    <div class="card">
+      <img src={card.image} alt={card.name}/>
+    </div>
+  )
+
+}

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -2,8 +2,6 @@ import './Card.css';
 import React from 'react';
 
 export const Card = (card) => {
-
-  console.log(this.props)
   
   return (
     <div className="card">

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -6,7 +6,7 @@ export const Card = (card) => {
   console.log(this.props)
   
   return (
-    <div class="card">
+    <div className="card">
       <img src={card.image} alt={card.name}/>
     </div>
   )

--- a/src/components/SelectedCards/SelectedCards.css
+++ b/src/components/SelectedCards/SelectedCards.css
@@ -1,1 +1,1 @@
-/* PLACEHOLDER */
+/* Most of the styles for this component reside in AvailableCards.css */

--- a/src/components/SelectedCards/SelectedCards.js
+++ b/src/components/SelectedCards/SelectedCards.js
@@ -17,7 +17,7 @@ export const SelectedCards = ({ cards }) => {
 
   return (
     <div className="cards-component" id="selected-component">
-      <h1>Selected Cards</h1>
+      <h2>Selected Cards/Deck Name</h2>
       <div className="cards-container">
         {displayCards}
       </div>

--- a/src/components/SelectedCards/SelectedCards.js
+++ b/src/components/SelectedCards/SelectedCards.js
@@ -1,13 +1,34 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import './SelectedCards.css';
+import { Card } from '../Card/Card'
 
-export const SelectedCards = () => {
+export const SelectedCards = ({ cards }) => {
+  let displayCards
+
+  if(cards) {
+    displayCards = cards.map(card => {
+    return <Card
+      key={card.id}
+      image={card.image_url}
+      name={card.name} />;
+    });
+  }
+
   return (
-    <div class="cards-component">
+    <div className="cards-component" id="selected-component">
       <h1>Selected Cards</h1>
-      <div class="cards-container" id="selected-container">
-        No cards to display yet.
+      <div className="cards-container">
+        {displayCards}
       </div>
     </div>
   );
-};
+}
+
+export const mapStateToProps = state => ({
+  cards: state.cards,
+  selectedCards: state.selectedCards,
+  availableCards: state.availableCards
+});
+
+export default connect(mapStateToProps)(SelectedCards);

--- a/src/components/SelectedCards/SelectedCards.js
+++ b/src/components/SelectedCards/SelectedCards.js
@@ -3,8 +3,11 @@ import './SelectedCards.css';
 
 export const SelectedCards = () => {
   return (
-    <div>
-      <h1>SelectedCards</h1>
+    <div class="cards-component">
+      <h1>Selected Cards</h1>
+      <div class="cards-container" id="selected-container">
+        No cards to display yet.
+      </div>
     </div>
   );
 };

--- a/src/containers/DeckBuilder/DeckBuilder.css
+++ b/src/containers/DeckBuilder/DeckBuilder.css
@@ -1,12 +1,39 @@
 .deck-builder {
   display: flex;
   position: absolute;
-  top: 100px;
-  bottom: 100px;
+  top: 50px;
+  bottom: 50px;
 }
 
 #class-info {
   width: 16%;
   text-align: center;
-  border: 1px solid black;
+  color: white; 
 }
+
+#class-info img {
+  width: 100%;
+}
+
+#class-info button {
+  display: block;
+  margin: 15px auto;
+}
+
+#class-info h2 {
+  margin: 10px 10px 10px 15px;
+}
+
+#class-info h3 {
+  display: inline-block;
+  margin: 10px;
+}
+
+#class-info h4 {
+  margin-bottom: 0;
+}
+
+#class-info button.inline-button {
+  display: inline-block;
+}
+

--- a/src/containers/DeckBuilder/DeckBuilder.css
+++ b/src/containers/DeckBuilder/DeckBuilder.css
@@ -1,1 +1,12 @@
-/* PLACEHOLDER */
+.deck-builder {
+  display: flex;
+  position: absolute;
+  top: 100px;
+  bottom: 100px;
+}
+
+#class-info {
+  width: 16%;
+  text-align: center;
+  border: 1px solid black;
+}

--- a/src/containers/DeckBuilder/DeckBuilder.js
+++ b/src/containers/DeckBuilder/DeckBuilder.js
@@ -29,6 +29,8 @@ export class DeckBuilder extends Component {
       const cards = await api.fetchCards(selectedClass);
       const selected = await helper.getSelected(this.state.deck, cards);
       const available = await helper.getAvailable(cards, selected);
+      this.setState({selectedClass})
+      addSelectedClass(selectedClass)
       addCards(cards);
       addSelectedCards(selected);
       addAvailableCards(available);
@@ -49,12 +51,18 @@ export class DeckBuilder extends Component {
       <div className="deck-builder">     
         <AvailableCards cards={this.props.availableCards} />
         <div id="class-info">
-          Class Image
-          Card X of X
-          Change Level
-          Save Deck Button
-          Change Class Button
-          Reset Deck Button
+          <h2>{this.state.selectedClass}</h2>
+          <img src='http://www.cephalofair.com/wp-content/uploads/2015/04/Inox-Brute1-731x1024.jpg'
+            alt="`{this.state.selectedClass} Class`" />
+          <h4>Cards Selected</h4>
+          <p>X of X</p>
+          <h4>Character Level</h4> 
+          <button className="inline-button">-</button>
+          <h3>9</h3>
+          <button className="inline-button">+</button>
+          <button>Save Deck</button>
+          <button>Reset Deck</button>
+          <button>Change Class</button>
         </div>
         <SelectedCards cards={this.props.selectedCards} />
       </div>

--- a/src/containers/DeckBuilder/DeckBuilder.js
+++ b/src/containers/DeckBuilder/DeckBuilder.js
@@ -1,9 +1,40 @@
 import React, { Component } from 'react';
-import {AvailableCards} from '../../components/AvailableCards/AvailableCards';
-import {SelectedCards} from '../../components/SelectedCards/SelectedCards';
+import { connect } from 'react-redux';
+import './DeckBuilder.css';
+import { addCards } from '../../actions';
+import { AvailableCards } from '../../components/AvailableCards/AvailableCards';
+import { SelectedCards } from '../../components/SelectedCards/SelectedCards';
 
-export default class DeckBuilder extends Component {
-  
+export class DeckBuilder extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      error: ''
+    };
+  };
+
+  async componentDidMount() {
+    try {
+      const selectedClass = this.props.location.pathname.slice(1);
+      const cards = await this.getCards(selectedClass);
+      this.props.addCards(cards)
+      console.log(this.props.cards)
+    } catch (error) {
+      this.setState({ error });
+    }
+  }
+
+  getCards = async (selectedClass) => {
+    const url = `http://localhost:8080/api/v1/cards/${selectedClass}`;
+
+    try {
+      const response = await fetch(url);
+      const cards = await response.json();
+      return cards
+    } catch (error) {
+      throw error("Error getting cards")}
+  }
+
   // THIS WILL BE A SMART COMPONENT THAT DISPLAYS THE
   // CLASS IMAGE AND INFORMATION in a middle column.
   // 
@@ -13,12 +44,28 @@ export default class DeckBuilder extends Component {
   
   render() {
     return (
-      <div>       
-        <AvailableCards/>
-        Class image and information go here. But vertical columns.
-        Like the wireframes. Ya know?
-        <SelectedCards/>
+      <div class="deck-builder">     
+        <AvailableCards cards={this.props.cards} />
+        <div id="class-info">
+          Class Image
+          Card X of X
+          Change Level
+          Save Deck Button
+          Change Class Button
+          Reset Deck Button
+        </div>
+        <SelectedCards />
       </div>
     )
   }
 };
+
+export const mapDispatchToProps = dispatch => ({
+  addCards: cards => dispatch(addCards(cards))
+});
+
+export const mapStateToProps = state => ({
+  cards: state.cards
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeckBuilder);

--- a/src/containers/DeckBuilder/DeckBuilder.js
+++ b/src/containers/DeckBuilder/DeckBuilder.js
@@ -1,17 +1,23 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import './DeckBuilder.css';
-import { addCards, addSelectedCards, addAvailableCards } from '../../actions';
 import { AvailableCards } from '../../components/AvailableCards/AvailableCards';
 import { SelectedCards } from '../../components/SelectedCards/SelectedCards';
 import * as api from '../../api/index'
 import * as helper from '../../helpers/index'
+import { 
+  addCards, 
+  addSelectedCards, 
+  addAvailableCards, 
+  addSelectedClass 
+  } from '../../actions';
 
 export class DeckBuilder extends Component {
   constructor(props) {
     super(props);
     this.state = {
       deck: 1,
+      selectedClass: '',
       error: ''
     };
   };
@@ -22,7 +28,7 @@ export class DeckBuilder extends Component {
       const selectedClass = this.props.location.pathname.slice(1);
       const cards = await api.fetchCards(selectedClass);
       const selected = await helper.getSelected(this.state.deck, cards);
-      const available = await helper.getAvailable(cards, selected)
+      const available = await helper.getAvailable(cards, selected);
       addCards(cards);
       addSelectedCards(selected);
       addAvailableCards(available);
@@ -60,14 +66,17 @@ export const mapDispatchToProps = dispatch => ({
   addCards: cards => dispatch(addCards(cards)),
   addSelectedCards: selectedCards => 
     dispatch(addSelectedCards(selectedCards)),
-  addAvailableCards: availableCards => 
-    dispatch(addAvailableCards(availableCards))
+  addAvailableCards: availableCards =>
+    dispatch(addAvailableCards(availableCards)),
+  addSelectedClass: selectedClass =>
+    dispatch(addSelectedClass(selectedClass))
 });
 
 export const mapStateToProps = state => ({
   cards: state.cards,
   selectedCards: state.selectedCards,
-  availableCards: state.availableCards
+  availableCards: state.availableCards,
+  selectedClass: state.selectedClass
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(DeckBuilder);

--- a/src/helpers/getAvailable.js
+++ b/src/helpers/getAvailable.js
@@ -1,0 +1,14 @@
+export const getAvailable = (cards, selected) => {
+  if (selected === []) {
+    return cards;
+  } else {
+    let available = [...cards]
+    selected.forEach(selectedCard => {
+      available = available.filter(availableCard => {
+        return availableCard.id !== selectedCard
+      })
+    })
+    return available
+  }
+}
+

--- a/src/helpers/getAvailable.js
+++ b/src/helpers/getAvailable.js
@@ -5,7 +5,7 @@ export const getAvailable = (cards, selected) => {
     let available = [...cards]
     selected.forEach(selectedCard => {
       available = available.filter(availableCard => {
-        return availableCard.id !== selectedCard
+        return availableCard.id !== selectedCard.id
       })
     })
     return available

--- a/src/helpers/getSelected.js
+++ b/src/helpers/getSelected.js
@@ -1,0 +1,12 @@
+import { fetchSelected } from '../api/fetchSelected'
+
+export const getSelected = async (deckId, cards) => {
+    if(deckId < 1) {
+      return []; 
+    } else {
+      const selectedIds = await fetchSelected(deckId);
+      const selected = cards.filter(card => selectedIds.includes(card.id))
+      return selected;
+    }
+  }
+

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,2 @@
+export { getSelected } from './getSelected'
+export { getAvailable } from './getAvailable'

--- a/src/reducers/availableCardsReducer.js
+++ b/src/reducers/availableCardsReducer.js
@@ -1,0 +1,17 @@
+const availableCardsReducer = (state = [], action) => {
+  switch (action.type) {
+    case 'ADD_AVAILABLE_CARD':
+      return [...state, ...action.availableCard];
+    case 'ADD_AVAILABLE_CARDS':
+      return [...action.availableCards];
+    case 'REMOVE_AVAILABLE_CARD':
+      return state.filter(card =>
+        card.id !== action.availableCard.id);
+    case 'REMOVE_AVAILABLE_CARDS':
+      return [];
+    default:
+      return state;
+  }
+};
+
+export default availableCardsReducer;

--- a/src/reducers/cardsReducer.js
+++ b/src/reducers/cardsReducer.js
@@ -1,0 +1,12 @@
+const cardsReducer = (state = [], action) => {
+  switch (action.type) {
+    case 'ADD_CARD':
+      return [...state, ...action.card];
+    case 'ADD_CARDS':
+      return [...action.cards];
+    default:
+      return state;
+  }
+};
+
+export default cardsReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,8 @@
 import { combineReducers } from 'redux';
+import cards from './cardsReducer';
 
 const rootReducer = combineReducers({
-
+  cards
 });
 
 export default rootReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,8 +1,12 @@
 import { combineReducers } from 'redux';
 import cards from './cardsReducer';
+import availableCards from './availableCardsReducer';
+import selectedCards from './selectedCardsReducer';
 
 const rootReducer = combineReducers({
-  cards
+  cards,
+  availableCards,
+  selectedCards
 });
 
 export default rootReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import cards from './cardsReducer';
 import availableCards from './availableCardsReducer';
 import selectedCards from './selectedCardsReducer';
+import selectedClass from './selectedClassReducer';
 
 const rootReducer = combineReducers({
   cards,
   availableCards,
-  selectedCards
+  selectedCards,
+  selectedClass
 });
 
 export default rootReducer;

--- a/src/reducers/selectedCardsReducer.js
+++ b/src/reducers/selectedCardsReducer.js
@@ -1,0 +1,17 @@
+const selectedCardsReducer = (state = [], action) => {
+  switch (action.type) {
+    case 'ADD_SELECTED_CARD':
+      return [...state, ...action.selectedCard];
+    case 'ADD_SELECTED_CARDS':
+      return [...action.selectedCards];
+    case 'REMOVE_SELECTED_CARD':
+      return state.filter(card =>
+        card.id !== action.selectedCard.id);
+    case 'REMOVE_SELECTED_CARDS':
+      return [];
+    default:
+      return state;
+  }
+};
+
+export default selectedCardsReducer;

--- a/src/reducers/selectedClassReducer.js
+++ b/src/reducers/selectedClassReducer.js
@@ -1,0 +1,12 @@
+const selectedClassReducer = (state = '', action) => {
+  switch (action.type) {
+    case 'ADD_SELECTED_CLASS':
+      return [{'class': action.selectedClass}];
+    case 'REMOVE_SELECTED_CLASS':
+      return '';
+    default:
+      return state;
+  }
+};
+
+export default selectedClassReducer;


### PR DESCRIPTION
Adds basic shell for deckbuilder and subcomponents.
Currently loads with class and deck hand-entered in state of deckbuilder.js (these will come from store or passed as a prop...ideally button click on prior screen will update selectedClass and deck in store and deckbuilder will render based on what's in the store).
AddSelectedClass action does not populate store (setState used until working).
No logic to move cards from one side to the other yet.
Everything in center column is hand-entered placeholders.
Need zoom on click feature.